### PR TITLE
Update SDCard.cpp

### DIFF
--- a/arduino-wav-sdcard/lib/sd_card/src/SDCard.cpp
+++ b/arduino-wav-sdcard/lib/sd_card/src/SDCard.cpp
@@ -31,6 +31,8 @@ SDCard::SDCard(const char *mount_point, gpio_num_t miso, gpio_num_t mosi, gpio_n
   ESP_LOGI(TAG, "Initializing SD card");
 
   sdmmc_host_t host = SDSPI_HOST_DEFAULT();
+  host.max_freq_khz = 4000; //4MHz works with most boards. Default doesn't work with all boards, increasing speed might improve performance but might break functionality depending on breakout board. 
+  
   sdspi_slot_config_t slot_config = SDSPI_SLOT_CONFIG_DEFAULT();
   slot_config.gpio_miso = miso;
   slot_config.gpio_mosi = mosi;


### PR DESCRIPTION
Adding a line to specify the SDSPI max frequency. Came across an issue where my Lolin32 esp32 couldn't detect the SD card on the default frequency so had to specify to a lower one to make it work. The choice of frequency came from seeing what is used in the SDFat Library for ESP's. 

I suspect the issue is more to do with the breakout board used for the micro SD than the esp32 or SD cards themselves. Limiting it to the lower speed should make it compatible with most (hopefully all) boards and can be increased if desired.