### PR TITLE
Fix IDF build errors

### DIFF
--- a/idf-wav-sdcard/lib/audio_output/src/DACOutput.cpp
+++ b/idf-wav-sdcard/lib/audio_output/src/DACOutput.cpp
@@ -6,7 +6,7 @@ void DACOutput::start(int sample_rate)
     // i2s config for writing both channels of I2S
     i2s_config_t i2s_config = {
         .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX | I2S_MODE_DAC_BUILT_IN),
-        .sample_rate = sample_rate,
+        .sample_rate = (uint32_t)sample_rate,
         .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
         .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
         .communication_format = (i2s_comm_format_t)(I2S_COMM_FORMAT_I2S_MSB),

--- a/idf-wav-sdcard/lib/audio_output/src/I2SOutput.cpp
+++ b/idf-wav-sdcard/lib/audio_output/src/I2SOutput.cpp
@@ -10,7 +10,7 @@ void I2SOutput::start(int sample_rate)
     // i2s config for writing both channels of I2S
     i2s_config_t i2s_config = {
         .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX),
-        .sample_rate = sample_rate,
+        .sample_rate = (uint32_t)sample_rate,
         .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
         .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
         .communication_format = (i2s_comm_format_t)(I2S_COMM_FORMAT_I2S),

--- a/idf-wav-sdcard/src/main.cpp
+++ b/idf-wav-sdcard/src/main.cpp
@@ -12,6 +12,7 @@
 #include "WAVFileWriter.h"
 #include "WAVFileReader.h"
 #include "config.h"
+#include "esp_timer.h"
 
 static const char *TAG = "app";
 


### PR DESCRIPTION
This PR fixes build errors that occurs when building the IDF project. It includes a missing header file as well as explicitly converting sample rate to match the correct variable type